### PR TITLE
Upgrade Cake to 0.17.0

### DIFF
--- a/src/Cake.Webpack/Cake.Webpack.csproj
+++ b/src/Cake.Webpack/Cake.Webpack.csproj
@@ -33,8 +33,8 @@
     <DocumentationFile>bin\Release\Cake.Webpack.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.14.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Cake.Core.0.14.0\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Cake.Webpack/packages.config
+++ b/src/Cake.Webpack/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.14.0" targetFramework="net45" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
 </packages>

--- a/tests/Cake.Webpack.Tests/Cake.Webpack.Tests.csproj
+++ b/tests/Cake.Webpack.Tests/Cake.Webpack.Tests.csproj
@@ -31,12 +31,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.14.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Cake.Core.0.14.0\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Cake.Testing, Version=0.14.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Cake.Testing.0.14.0\lib\net45\Cake.Testing.dll</HintPath>
+    <Reference Include="Cake.Testing, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Cake.Testing.0.17.1\lib\net45\Cake.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Shouldly, Version=2.8.0.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">

--- a/tests/Cake.Webpack.Tests/packages.config
+++ b/tests/Cake.Webpack.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.14.0" targetFramework="net45" />
-  <package id="Cake.Testing" version="0.14.0" targetFramework="net45" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
+  <package id="Cake.Testing" version="0.17.1" targetFramework="net45" />
   <package id="Shouldly" version="2.8.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />


### PR DESCRIPTION
Cake 0.18.0 will requires at least version 0.16.x to work.